### PR TITLE
Need to sort url parameters, in V4 Signature

### DIFF
--- a/S3.php
+++ b/S3.php
@@ -2040,6 +2040,7 @@ class S3
 		if (strpos($uri, '?')) {
 			list ($uri, $query_str) = @explode("?", $uri);
 			parse_str($query_str, $parameters);
+			ksort($parameters); //parameters need to be in sorted order
 		}
 
 		// CanonicalRequests


### PR DESCRIPTION
Found this fork that adds V4 verification - which is great. 

But run into problem, found the URL params needs to be sorted (eg when runing ListObjects on a bucket, it adds multiple when using delimiter+prefix for example)
https://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html

Thought worth pushing this upstream. 

This is the same change made in our copy https://github.com/geograph-project/geograph-project/commit/466592a154069ccb92898a8f992d62b61034cc57